### PR TITLE
Calculate photoresistor and some other fixes

### DIFF
--- a/code/b-parasite/src/main.c
+++ b/code/b-parasite/src/main.c
@@ -63,12 +63,12 @@ static void rtc_callback() {
   prst_pwm_stop();
   nrf_gpio_pin_clear(PRST_FAST_DISCH_PIN);
 
-  nrf_gpio_pin_set(PRST_PHOTO_V);                                         // set GPIO for photoresistor HIGH
-  prst_adc_photo_sensor prst_adc_photo_read(double battery_voltage);      // read PHOTO SENSOR value
-  nrf_gpio_pin_clear(PRST_PHOTO_V);                                       // not sure need this one
+  nrf_gpio_pin_set(PRST_PHOTO_V);                                               // set GPIO for photoresistor HIGH
+  prst_adc_photo_sensor_t photo_read = prst_adc_photo_read(batt_read.voltage);  // read PHOTO SENSOR value
+  nrf_gpio_pin_clear(PRST_PHOTO_V);                                             // clear GPIO for photoresistor
 
   prst_ble_update_adv_data(batt_read.millivolts, temp_humi.temp_millicelcius,
-                           temp_humi.humidity, soil_read.relative, prst_adc_photo_sensor.lux, run_counter);
+                           temp_humi.humidity, soil_read.relative, photo_read.lux, run_counter);
   prst_adv_start();
   nrf_delay_ms(PRST_BLE_ADV_TIME_IN_MS);
   prst_adv_stop();

--- a/code/b-parasite/src/prst/adc.c
+++ b/code/b-parasite/src/prst/adc.c
@@ -130,22 +130,15 @@ prst_adc_soil_moisture_t prst_adc_soil_read(double battery_voltage) {
   return ret;
 }
 
-static inline double get_lux_level(double battery_voltage, nrf_saadc_value_t raw_adc_output) {
-  const double x = battery_voltage;
-
-  // todo: add DEBUG lines
-
-  return 0;   // place holder. need to map values to lux level.
-}
-
-prst_adc_photo_sensor prst_adc_photo_read(double battery_voltage) {
-  nrf_saadc_value_t raw_adc_output = sample_adc_channel(PRST_ADC_PHOTO_CHANNEL);
-  const uint16_t lux = get_lux_level(battery_voltage, raw_adc_output);
-  prst_adc_photo_sensor ret;
-  ret.raw = raw_adc_output;
-  ret.lux = lux;      
-
-  // todo: add DEBUG lines
-  
+prst_adc_photo_sensor_t prst_adc_photo_read(double battery_voltage) {
+  nrf_saadc_value_t raw_photo_output = sample_adc_channel(PRST_ADC_PHOTO_CHANNEL);
+  prst_adc_photo_sensor_t ret;
+  ret.raw = raw_photo_output;
+  ret.voltage = (3.6 * raw_photo_output) / (1 << PRST_ADC_RESOLUTION);
+  ret.lux = (uint16_t)ret.voltage*100000/(battery_voltage-ret.voltage);
+#if PRST_ADC_SOIL_DEBUG
+  NRF_LOG_INFO("[adc] Read lux level: %d (raw); %d (lux)",
+               ret.raw, ret.lux);
+#endif
   return ret;
 }

--- a/code/b-parasite/src/prst/adc.h
+++ b/code/b-parasite/src/prst/adc.h
@@ -18,9 +18,11 @@ typedef struct prst_adc_soil_moisture {
 
 typedef struct prst_adc_photo_sensor {
   int16_t raw;
-  // Should check minimum and maximum values
+  // A value from 0x0000 (no light) 0xffff (direct sun).
+  // Might need calibration.
+  double voltage;
   uint16_t lux;
-} prst_adc_photo_sensor;
+} prst_adc_photo_sensor_t;
 
 void prst_adc_init();
 
@@ -28,6 +30,6 @@ prst_adc_batt_read_t prst_adc_batt_read();
 
 prst_adc_soil_moisture_t prst_adc_soil_read(double battery_voltage);
 
-prst_adc_photo_sensor prst_adc_photo_read(double battery_voltage);
+prst_adc_photo_sensor_t prst_adc_photo_read(double battery_voltage);
 
 #endif  // _PRST_ADC_H_


### PR DESCRIPTION
prst_adc_photo_read() now calculates the photo resistor and return it as the lux level.
Added debug logging and fixed some syntax errors.